### PR TITLE
Fix broken API url on dataset landing page

### DIFF
--- a/ckanext/dundee/templates/package/search.html
+++ b/ckanext/dundee/templates/package/search.html
@@ -1,0 +1,24 @@
+{% ckan_extends %}                                                                                                                            
+                                                                                                                                              
+{% block package_search_results_api %}                                                                                                        
+  <section class="module">                                                                                                                    
+    <div class="module-content">                                                                                                              
+      {% block package_search_results_api_inner %}                                                                                            
+      <small>                                                                                                                                 
+        {% set api_link = h.link_to(_('API'), '/api/3/action/status_show') %}                                                                    
+        {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}                      
+        {% if g.dumps_url -%}                                                                                                                 
+          {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}                                 
+          {% trans %}                                                                                                                         
+            You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.                
+          {% endtrans %}                                                                                                                      
+        {% else %}                                                                                                                            
+           {% trans %}                                                                                                                         
+            You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).                                               
+          {% endtrans %}                                                                                                                      
+        {%- endif %}                                                                                                                          
+      </small>                                                                                                                                
+      {% endblock %}                                                                                                                          
+    </div>                                                                                                                                    
+  </section>                                                                                                                                  
+{% endblock %}

--- a/ckanext/dundee/templates/package/search.html
+++ b/ckanext/dundee/templates/package/search.html
@@ -1,24 +1,17 @@
-{% ckan_extends %}                                                                                                                            
-                                                                                                                                              
-{% block package_search_results_api %}                                                                                                        
-  <section class="module">                                                                                                                    
-    <div class="module-content">                                                                                                              
-      {% block package_search_results_api_inner %}                                                                                            
-      <small>                                                                                                                                 
-        {% set api_link = h.link_to(_('API'), '/api/3/action/status_show') %}                                                                    
-        {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}                      
-        {% if g.dumps_url -%}                                                                                                                 
-          {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}                                 
-          {% trans %}                                                                                                                         
-            You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.                
-          {% endtrans %}                                                                                                                      
-        {% else %}                                                                                                                            
-           {% trans %}                                                                                                                         
-            You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).                                               
-          {% endtrans %}                                                                                                                      
-        {%- endif %}                                                                                                                          
-      </small>                                                                                                                                
-      {% endblock %}                                                                                                                          
-    </div>                                                                                                                                    
-  </section>                                                                                                                                  
-{% endblock %}
+{% ckan_extends %}                                                                                                                                                                                                                                         
+  {% block package_search_results_api_inner %}                                                                                            
+  <small>                                                                                                                                 
+    {% set api_link = h.link_to(_('API'), '/api/3/action/status_show') %}                                                                    
+    {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}                      
+    {% if g.dumps_url -%}                                                                                                                 
+      {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}                                 
+      {% trans %}                                                                                                                         
+        You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.                
+      {% endtrans %}                                                                                                                      
+    {% else %}                                                                                                                            
+       {% trans %}                                                                                                                         
+        You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).                                               
+      {% endtrans %}                                                                                                                      
+    {%- endif %}                                                                                                                          
+  </small>                                                                                                                                
+  {% endblock %}                                                                                                                          


### PR DESCRIPTION
Provides a temporary fix for https://gitlab.com/datopian/core/support/-/issues/206#note_321269873
until the instance is upgraded to the latest version of ckan

## Problem
* In ckan 2.7 the link /api/ doesnt work which works in 2.6 and 2.8.
* The api link on the dataset landing page redirects to random pages instead of redirecting to /api/3 or to /api/action/status_show if /api/3 is 404.

## Solution implemented in PR
This PR adds a /package/search.html file in the templates folder of the extension which overrides the existing search.html template and redirects the api link in the dataset landing page to /api/action/status_show